### PR TITLE
Fix serveDocs()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,7 @@ export function serveDocs(app: App, opts: serveOptions) {
   const __dirname = dirname(modulePath)
 
   const template = readFileSync(resolve(__dirname, 'template.html'), 'utf8')
-  const html = template.replace('"##docs##"', strDocs).replace('"##title##"', opts.title)
+  const html = template.replace("'##docs##'", strDocs).replace('"##title##"', opts.title)
 
   app.get('/' + prefix, (_req: Request, res: Response) => {
     res.status(200).send(html)


### PR DESCRIPTION
Modify the replace call so that the specification in the template ends up as a JS object and not a string, which causes issues with SwaggerUIBundle.

Fixes https://github.com/tinyhttp/swagger/issues/8